### PR TITLE
Add markdown fenced code highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,16 @@
                 "language": "swift",
                 "scopeName": "source.swift",
                 "path": "./syntaxes/swift.tmLanguage.json"
+            },
+            {
+                "scopeName": "markdown.swift.codeblock",
+                "path": "./syntaxes/codeblock.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ],
+                "embeddedLanguages": {
+                    "meta.embedded.block.swift": "javascript"
+                }
             }
         ]
     },

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -1,0 +1,28 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:markup.fenced_code.block.markdown",
+	"patterns": [
+		{
+			"include": "#swift-code-block"
+		}
+	],
+	"repository": {
+		"swift-code-block": {
+			"begin": "(?<=[`~])swift(\\s+[^`~]*)?$",
+			"end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",  
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.swift",
+					"patterns": [
+						{
+							"include": "source.swift"
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "markdown.swift.codeblock"
+}


### PR DESCRIPTION
This enables Swift syntax highlighting inside fenced code blocks in Markdown files.